### PR TITLE
Fix Homebrew formula workflow: add setuptools for poet

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          pip install "langfuse-cli==$PKG_VERSION" homebrew-pypi-poet
+          pip install setuptools "langfuse-cli==$PKG_VERSION" homebrew-pypi-poet
           poet -f langfuse-cli > langfuse-cli.rb
 
       - name: Checkout tap repo


### PR DESCRIPTION
## Summary
- `homebrew-pypi-poet` depends on `pkg_resources` which is no longer bundled with Python 3.12+
- Adds `setuptools` to the pip install step to provide the missing module
- Fixes the v0.1.0 Homebrew formula update that failed after PyPI publish

## Test plan
- [ ] Re-run the Update Homebrew Formula workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)