### PR TITLE
Fix Homebrew formula: add dependency resource blocks

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Get release version
         id: version
         env:
@@ -41,35 +43,8 @@ jobs:
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          SHA256=$(curl -s "https://pypi.org/pypi/langfuse-cli/${PKG_VERSION}/json" | python3 -c "
-          import sys, json
-          data = json.load(sys.stdin)
-          for f in data['urls']:
-              if f['filename'].endswith('.tar.gz'):
-                  print(f['digests']['sha256'])
-                  break
-          ")
-          python3 -c "
-          print('''class LangfuseCli < Formula
-            include Language::Python::Virtualenv
-
-            desc \"CLI tool for Langfuse LLM observability platform\"
-            homepage \"https://github.com/aviadshiber/langfuse-cli\"
-            url \"https://pypi.io/packages/source/l/langfuse-cli/langfuse_cli-${PKG_VERSION}.tar.gz\"
-            sha256 \"${SHA256}\"
-            license \"MIT\"
-
-            depends_on \"python@3.12\"
-
-            def install
-              virtualenv_install_with_resources
-            end
-
-            test do
-              assert_match version.to_s, shell_output(\"#{bin}/lf --version\")
-            end
-          end''')
-          " > langfuse-cli.rb
+          pip install "langfuse-cli==$PKG_VERSION"
+          python3 scripts/generate-formula.py "$PKG_VERSION" > langfuse-cli.rb
           echo "Generated formula:"
           cat langfuse-cli.rb
 

--- a/scripts/generate-formula.py
+++ b/scripts/generate-formula.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Generate a Homebrew formula for langfuse-cli with all Python dependency resources.
+
+Usage: python3 scripts/generate-formula.py <version>
+
+Requires: pip install langfuse-cli==<version> (so pip can resolve dependencies)
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.request
+
+
+def get_pypi_sdist(package: str, version: str | None = None) -> tuple[str, str]:
+    """Get the sdist URL and sha256 for a package from PyPI."""
+    url = f"https://pypi.org/pypi/{package}/{version}/json" if version else f"https://pypi.org/pypi/{package}/json"
+    with urllib.request.urlopen(url) as resp:
+        data = json.loads(resp.read())
+
+    releases = data.get("urls", [])
+
+    for file_info in releases:
+        if file_info["filename"].endswith(".tar.gz"):
+            return file_info["url"], file_info["digests"]["sha256"]
+
+    # Fallback to .zip sdist
+    for file_info in releases:
+        if file_info["packagetype"] == "sdist":
+            return file_info["url"], file_info["digests"]["sha256"]
+
+    raise ValueError(f"No sdist found for {package}=={version}")
+
+
+def get_installed_deps(exclude: str) -> list[tuple[str, str]]:
+    """Get all installed packages except the main package and pip/setuptools."""
+    import importlib.metadata
+
+    # Skip the main package, build tools, and dev-only dependencies
+    skip = {
+        exclude.lower(), "pip", "setuptools", "wheel", "pkg-resources",
+        # Dev dependencies that should not be in the formula
+        "pytest", "pytest-cov", "pytest-mock", "respx", "ruff", "mypy",
+        "mypy-extensions", "mypy_extensions", "coverage", "iniconfig", "pluggy",
+        "pathspec", "librt",
+    }
+    deps = []
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata["Name"].lower()
+        if name not in skip:
+            deps.append((dist.metadata["Name"], dist.metadata["Version"]))
+    return sorted(set(deps), key=lambda x: x[0].lower())
+
+
+def generate_formula(version: str) -> str:
+    """Generate the complete Homebrew formula."""
+    pkg_url, pkg_sha256 = get_pypi_sdist("langfuse-cli", version)
+
+    deps = get_installed_deps("langfuse-cli")
+    resource_blocks = []
+    for dep_name, dep_version in deps:
+        try:
+            dep_url, dep_sha256 = get_pypi_sdist(dep_name, dep_version)
+            resource_blocks.append(
+                f'  resource "{dep_name}" do\n'
+                f'    url "{dep_url}"\n'
+                f'    sha256 "{dep_sha256}"\n'
+                f"  end\n"
+            )
+        except (ValueError, urllib.error.HTTPError) as e:
+            print(f"WARNING: Skipping {dep_name}=={dep_version}: {e}", file=sys.stderr)
+
+    resources = "\n".join(resource_blocks)
+
+    return f'''class LangfuseCli < Formula
+  include Language::Python::Virtualenv
+
+  desc "CLI tool for Langfuse LLM observability platform"
+  homepage "https://github.com/aviadshiber/langfuse-cli"
+  url "{pkg_url}"
+  sha256 "{pkg_sha256}"
+  license "MIT"
+
+  depends_on "python@3.12"
+
+{resources}
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{{bin}}/lf --version")
+  end
+end'''
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <version>", file=sys.stderr)
+        sys.exit(1)
+    print(generate_formula(sys.argv[1]))


### PR DESCRIPTION
## Summary
- Homebrew formula was missing Python dependency resource blocks
- `brew install` succeeded but `lf` failed with `ModuleNotFoundError: No module named 'typer'`
- Added `scripts/generate-formula.py` that queries PyPI JSON API for all dependency sdist URLs/sha256
- Updated workflow to checkout source repo first, then run the script

## Test plan
- [ ] Merge and trigger `gh workflow run update-homebrew.yml`
- [ ] `brew install aviadshiber/tap/langfuse-cli`
- [ ] `lf --version` returns `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)