### PR TITLE
Exclude Linux-only keyring deps from Homebrew formula

### DIFF
--- a/scripts/generate-formula.py
+++ b/scripts/generate-formula.py
@@ -43,6 +43,8 @@ def get_installed_deps(exclude: str) -> list[tuple[str, str]]:
         "pytest", "pytest-cov", "pytest-mock", "respx", "ruff", "mypy",
         "mypy-extensions", "mypy_extensions", "coverage", "iniconfig", "pluggy",
         "pathspec", "librt",
+        # Linux-only keyring backends (cryptography needs Rust to build from source)
+        "secretstorage", "jeepney", "cryptography", "cffi", "pycparser",
     }
     deps = []
     for dist in importlib.metadata.distributions():


### PR DESCRIPTION
## Summary
- `cryptography` package fails to build from source in Homebrew (needs Rust/maturin)
- It's only needed via `SecretStorage` → `jeepney` → `cryptography`, which is a Linux-only keyring backend
- macOS uses Keychain natively via the `keyring` package, no need for these
- Excludes `secretstorage`, `jeepney`, `cryptography`, `cffi`, `pycparser` from formula

## Test plan
- [ ] Merge, trigger workflow, `brew install aviadshiber/tap/langfuse-cli`
- [ ] `lf --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)