### PR TITLE
Simplify Homebrew formula: use pip install with wheels

### DIFF
--- a/scripts/generate-formula.py
+++ b/scripts/generate-formula.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Generate a Homebrew formula for langfuse-cli with all Python dependency resources.
+"""Generate a Homebrew formula for langfuse-cli.
 
 Usage: python3 scripts/generate-formula.py <version>
 
-Requires: pip install langfuse-cli==<version> (so pip can resolve dependencies)
+Uses pip install with binary wheels to avoid building Rust-based
+dependencies (jiter, pydantic_core, cryptography) from source.
 """
 from __future__ import annotations
 
@@ -12,82 +13,42 @@ import sys
 import urllib.request
 
 
-def get_pypi_sdist(package: str, version: str | None = None) -> tuple[str, str]:
-    """Get the sdist URL and sha256 for a package from PyPI."""
-    url = f"https://pypi.org/pypi/{package}/{version}/json" if version else f"https://pypi.org/pypi/{package}/json"
+def get_pypi_sha256(package: str, version: str) -> str:
+    """Get the sdist sha256 for a package from PyPI."""
+    url = f"https://pypi.org/pypi/{package}/{version}/json"
     with urllib.request.urlopen(url) as resp:
         data = json.loads(resp.read())
 
-    releases = data.get("urls", [])
-
-    for file_info in releases:
+    for file_info in data.get("urls", []):
         if file_info["filename"].endswith(".tar.gz"):
-            return file_info["url"], file_info["digests"]["sha256"]
+            return file_info["digests"]["sha256"]
 
-    # Fallback to .zip sdist
-    for file_info in releases:
+    for file_info in data.get("urls", []):
         if file_info["packagetype"] == "sdist":
-            return file_info["url"], file_info["digests"]["sha256"]
+            return file_info["digests"]["sha256"]
 
     raise ValueError(f"No sdist found for {package}=={version}")
 
 
-def get_installed_deps(exclude: str) -> list[tuple[str, str]]:
-    """Get all installed packages except the main package and pip/setuptools."""
-    import importlib.metadata
-
-    # Skip the main package, build tools, and dev-only dependencies
-    skip = {
-        exclude.lower(), "pip", "setuptools", "wheel", "pkg-resources",
-        # Dev dependencies that should not be in the formula
-        "pytest", "pytest-cov", "pytest-mock", "respx", "ruff", "mypy",
-        "mypy-extensions", "mypy_extensions", "coverage", "iniconfig", "pluggy",
-        "pathspec", "librt",
-        # Linux-only keyring backends (cryptography needs Rust to build from source)
-        "secretstorage", "jeepney", "cryptography", "cffi", "pycparser",
-    }
-    deps = []
-    for dist in importlib.metadata.distributions():
-        name = dist.metadata["Name"].lower()
-        if name not in skip:
-            deps.append((dist.metadata["Name"], dist.metadata["Version"]))
-    return sorted(set(deps), key=lambda x: x[0].lower())
-
-
 def generate_formula(version: str) -> str:
-    """Generate the complete Homebrew formula."""
-    pkg_url, pkg_sha256 = get_pypi_sdist("langfuse-cli", version)
-
-    deps = get_installed_deps("langfuse-cli")
-    resource_blocks = []
-    for dep_name, dep_version in deps:
-        try:
-            dep_url, dep_sha256 = get_pypi_sdist(dep_name, dep_version)
-            resource_blocks.append(
-                f'  resource "{dep_name}" do\n'
-                f'    url "{dep_url}"\n'
-                f'    sha256 "{dep_sha256}"\n'
-                f"  end\n"
-            )
-        except (ValueError, urllib.error.HTTPError) as e:
-            print(f"WARNING: Skipping {dep_name}=={dep_version}: {e}", file=sys.stderr)
-
-    resources = "\n".join(resource_blocks)
+    """Generate the Homebrew formula."""
+    sha256 = get_pypi_sha256("langfuse-cli", version)
 
     return f'''class LangfuseCli < Formula
   include Language::Python::Virtualenv
 
   desc "CLI tool for Langfuse LLM observability platform"
   homepage "https://github.com/aviadshiber/langfuse-cli"
-  url "{pkg_url}"
-  sha256 "{pkg_sha256}"
+  url "https://files.pythonhosted.org/packages/source/l/langfuse-cli/langfuse_cli-{version}.tar.gz"
+  sha256 "{sha256}"
   license "MIT"
 
   depends_on "python@3.12"
 
-{resources}
   def install
-    virtualenv_install_with_resources
+    virtualenv_create(libexec, "python3.12")
+    system libexec/"bin/pip", "install", "langfuse-cli==#{{version}}"
+    bin.install_symlink Dir[libexec/"bin/lf"]
   end
 
   test do


### PR DESCRIPTION
## Summary
- Resource blocks + sdist builds fail for Rust-based deps (jiter, pydantic_core)
- Switched to `pip install langfuse-cli==VERSION` which uses pre-built binary wheels
- Formula: create venv, pip install, symlink binary

## Test plan
- [ ] `brew install aviadshiber/tap/langfuse-cli`
- [ ] `lf --version` returns `0.1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)