### PR TITLE
fix(observations): use fromStartTime/toStartTime for the observations endpoint (#39)

### DIFF
--- a/src/langfuse_cli/client.py
+++ b/src/langfuse_cli/client.py
@@ -170,7 +170,13 @@ class LangfuseClient:
         to_timestamp: datetime | None = None,
         metadata: list[tuple[str, str]] | None = None,
     ) -> list[dict[str, Any]]:
-        """List observations with optional filters."""
+        """List observations with optional filters.
+
+        Note: `/api/public/observations` filters on `fromStartTime` / `toStartTime`,
+        unlike `/api/public/traces` and `/api/public/sessions` which use
+        `fromTimestamp` / `toTimestamp`. Sending the latter to the observations
+        endpoint is silently ignored by the API.
+        """
         params: dict[str, Any] = {}
         if trace_id:
             params["traceId"] = trace_id
@@ -179,9 +185,9 @@ class LangfuseClient:
         if name:
             params["name"] = name
         if from_timestamp:
-            params["fromTimestamp"] = _iso_with_tz(from_timestamp)
+            params["fromStartTime"] = _iso_with_tz(from_timestamp)
         if to_timestamp:
-            params["toTimestamp"] = _iso_with_tz(to_timestamp)
+            params["toStartTime"] = _iso_with_tz(to_timestamp)
         if metadata:
             params["filter"] = _build_metadata_filter(metadata)
         return list(self._paginate("/observations", params, limit))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -491,13 +491,16 @@ class TestObservationsMethods:
         )
 
         assert mock_route.called
-        request = mock_route.calls.last.request
-        url_str = str(request.url)
-        assert "fromStartTime=2024-01-01T00%3A00%3A00%2B00%3A00" in url_str
-        assert "toStartTime=2024-01-31T00%3A00%3A00%2B00%3A00" in url_str
-        # Negative assertion: the trace/session-style names must not leak through.
-        assert "fromTimestamp=" not in url_str
-        assert "toTimestamp=" not in url_str
+        params = mock_route.calls.last.request.url.params
+
+        # Positive: observations endpoint must carry fromStartTime / toStartTime.
+        assert params.get("fromStartTime") == "2024-01-01T00:00:00+00:00"
+        assert params.get("toStartTime") == "2024-01-31T00:00:00+00:00"
+
+        # Regression guard for #39: the trace/session-style names must never leak
+        # back in via a future refactor that unifies param assembly.
+        assert "fromTimestamp" not in params
+        assert "toTimestamp" not in params
 
 
 class TestDatasetMethods:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -467,7 +467,13 @@ class TestObservationsMethods:
 
     @respx.mock
     def test_list_observations_with_timestamps(self, client: LangfuseClient) -> None:
-        """Test list_observations() passes timestamp filters."""
+        """Test list_observations() passes timestamp filters using the observations-endpoint param names.
+
+        Regression for #39: `/api/public/observations` filters on `fromStartTime` /
+        `toStartTime`, NOT `fromTimestamp` / `toTimestamp` (which are correct for
+        `/traces` and `/sessions`). Sending the wrong names is silently ignored by
+        the Langfuse API.
+        """
         mock_route = respx.get("https://test.langfuse.com/api/public/observations").mock(
             return_value=httpx.Response(
                 200,
@@ -487,8 +493,11 @@ class TestObservationsMethods:
         assert mock_route.called
         request = mock_route.calls.last.request
         url_str = str(request.url)
-        assert "fromTimestamp=2024-01-01T00%3A00%3A00%2B00%3A00" in url_str
-        assert "toTimestamp=2024-01-31T00%3A00%3A00%2B00%3A00" in url_str
+        assert "fromStartTime=2024-01-01T00%3A00%3A00%2B00%3A00" in url_str
+        assert "toStartTime=2024-01-31T00%3A00%3A00%2B00%3A00" in url_str
+        # Negative assertion: the trace/session-style names must not leak through.
+        assert "fromTimestamp=" not in url_str
+        assert "toTimestamp=" not in url_str
 
 
 class TestDatasetMethods:


### PR DESCRIPTION
## Summary

- `lf observations list --from / --to` was silently ignored — Langfuse's `/api/public/observations` endpoint filters on `fromStartTime` / `toStartTime`, not the trace/session-style `fromTimestamp` / `toTimestamp`. Unknown query params are dropped by the API, so every query returned the latest rows regardless of window.
- Switch `LangfuseClient.list_observations` to the correct query-param names. Traces and sessions keep `fromTimestamp` / `toTimestamp` (verified against the OpenAPI spec — those endpoints really do use those names).
- Regression test in `tests/test_client.py` now asserts the new names and explicitly fails if the old names leak back in.

## Evidence

Pulled from https://cloud.langfuse.com/generated/api/openapi.yml at the time of writing:

| Endpoint | From-param | To-param |
|---|---|---|
| `/api/public/traces` | `fromTimestamp` | `toTimestamp` |
| `/api/public/sessions` | `fromTimestamp` | `toTimestamp` |
| `/api/public/observations` | **`fromStartTime`** | **`toStartTime`** |
| `/api/public/v2/observations` | **`fromStartTime`** | **`toStartTime`** |

## Test plan

- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run mypy src/` — passes (0 issues)
- [x] `uv run pytest -q` — 345 passed, coverage 95.67%
- [x] Live verification against a real Langfuse project (after `uv pip install -e .`):
  - Before fix: `lf --json observations list -n generated_questions --from 2026-03-29 --to 2026-04-01 --limit 5` → 5 rows from 2026-05-28 (filter ignored)
  - After fix: same command → 5 rows with `startTime` in `2026-03-31` (in window)
  - Adjacent non-overlapping windows (`03-29 → 04-15`, `04-15 → 05-01`, no `--to`) all return distinct, correctly-bounded data.

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)